### PR TITLE
Override path to css using a environment variable

### DIFF
--- a/nbconflux/api.py
+++ b/nbconflux/api.py
@@ -6,7 +6,7 @@ from traitlets.config import Config
 
 def notebook_to_page(notebook_file, confluence_url, username=None, password=None,
                      generate_toc=True, attach_ipynb=True, enable_style=True, enable_mathjax=False,
-                     extra_labels=None):
+                     extra_labels=None, notebook_css=None):
     """Transforms the given notebook file into Confluence storage format and
     updates the given Confluence URL with its content.
 
@@ -35,6 +35,8 @@ def notebook_to_page(notebook_file, confluence_url, username=None, password=None
         Include the MathJax script and configuration (default: False)
     extra_labels: list, optional
         Additional labels to add to the page (default: None)
+    notebook_css: str, optional
+        Override path to notebook css (default: None - Use nbviewer.jupyter.org one)
     """
     if username is None:
         username = getpass.getuser()
@@ -52,6 +54,8 @@ def notebook_to_page(notebook_file, confluence_url, username=None, password=None
     c.ConfluenceExporter.enable_style = enable_style
     c.ConfluenceExporter.enable_mathjax = enable_mathjax
     c.ConfluenceExporter.extra_labels = extra_labels
+    if notebook_css:
+        c.ConfluenceExporter.notebook_css = notebook_css
 
     exporter = ConfluenceExporter(c)
     result = exporter.from_filename(notebook_file)

--- a/nbconflux/cli.py
+++ b/nbconflux/cli.py
@@ -51,10 +51,11 @@ def main(argv=None):
     if password is None:
         password = getpass.getpass('Confluence password: ')
 
+    notebook_path_css = os.getenv('NBCONFLUX_NOTEBOOK_CSS', None)
     notebook_to_page(args.notebook, args.url, username, password,
                      generate_toc=not args.exclude_toc, attach_ipynb=not args.exclude_ipynb,
                      enable_style=not args.exclude_style, enable_mathjax=args.include_mathjax,
-                     extra_labels=args.extra_labels)
+                     extra_labels=args.extra_labels, notebook_css=notebook_path_css)
 
 if __name__ == '__main__':
     main()

--- a/nbconflux/confluence.tpl
+++ b/nbconflux/confluence.tpl
@@ -203,7 +203,7 @@ unknown type  {{ cell.type }}
 {%- endif %}
 
 <ac:structured-macro ac:macro-id="8250dedf-fcaa-48da-b12d-0f929c620dc4" ac:name="style" ac:schema-version="1">
-    <ac:parameter ac:name="import">https://nbviewer.jupyter.org/static/build/notebook.css</ac:parameter>
+    <ac:parameter ac:name="import">{{ resources['notebook_css'] }}</ac:parameter>
 </ac:structured-macro>
 
 <ac:structured-macro ac:macro-id="8250dedf-fcaa-48da-b12d-0f929c620dc4" ac:name="style" ac:schema-version="1">

--- a/nbconflux/exporter.py
+++ b/nbconflux/exporter.py
@@ -14,6 +14,8 @@ from nbconvert.filters.markdown_mistune import MarkdownWithMath
 from traitlets import Bool, List, Unicode
 from traitlets.config import Config
 
+DEFAULT_CSS = "https://nbviewer.jupyter.org/static/build/notebook.css"
+
 
 class ConfluenceExporter(HTMLExporter):
     """Converts a notebook into Confluence storage format XHTML and the
@@ -43,6 +45,8 @@ class ConfluenceExporter(HTMLExporter):
         Add the Jupyter base stylesheet to the page (default: True)
     enable_mathjax: traitlets.Bool
         Add MathJax to the page to render equations (default: False)
+    notebooks_css: traitlets.Unicode
+        Path to notebook css (default: "https://nbviewer.jupyter.org/static/build/notebook.css")
     """
     url = Unicode(config=True, help='Confluence URL to update with notebook content')
     username = Unicode(config=True, help='Confluence username')
@@ -52,6 +56,7 @@ class ConfluenceExporter(HTMLExporter):
     enable_style = Bool(config=True, default_value=True, help='Add basic Jupyter stylesheet?')
     enable_mathjax = Bool(config=True, default_value=False, help='Add MathJax to the page to render equations?')
     extra_labels = List(config=True, trait=Unicode(), help='List of additional labels to add to the page')
+    notebook_css = Unicode(config=True, default_value=DEFAULT_CSS, help="Path to the CSS")
 
     @property
     def default_config(self):
@@ -304,6 +309,7 @@ class ConfluenceExporter(HTMLExporter):
         resources['generate_toc'] = self.generate_toc
         resources['enable_mathjax'] = self.enable_mathjax
         resources['enable_style'] = self.enable_style
+        resources['notebook_css'] = self.notebook_css
 
         # Convert the notebook to Confluence storage format, which is XHTML-like
         html, resources = super(ConfluenceExporter, self).from_notebook_node(nb, resources, **kw)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ def argv():
 
 
 def mock_notebook_to_page(notebook, url, username, password, generate_toc, attach_ipynb,
-                          enable_style, enable_mathjax, extra_labels):
+                          enable_style, enable_mathjax, extra_labels, notebook_css):
     assert notebook == 'fake-notebook.ipynb'
     assert url == 'https://confluence.localhost/some/page'
     assert username == 'fake-username'
@@ -27,6 +27,7 @@ def mock_notebook_to_page(notebook, url, username, password, generate_toc, attac
     assert not enable_style
     assert enable_mathjax
     assert extra_labels == ['extra-label-1', 'extra-label-2']
+    assert notebook_css is None
 
 
 def test_cli_args(argv, monkeypatch):

--- a/tests/test_nbconflux.py
+++ b/tests/test_nbconflux.py
@@ -106,6 +106,8 @@ def test_post_to_confluence(notebook_path, page_url, server):
     assert '<a href="http://confluence.localhost/download/attachments/12345/nbconflux-test.ipynb?version=1">nbconflux-test.ipynb</a>' in html
     # MathJax not included
     assert 'MathJax' not in html
+    # default css
+    assert 'https://nbviewer.jupyter.org/static/build/notebook.css' in html
 
     # Default label added to page
     req = server.calls[4].request
@@ -181,7 +183,7 @@ def test_optional_components(notebook_path, page_url, server):
     # Mock updating image attachment, but not the notebook attachment
     server.add('POST', 'http://confluence.localhost/rest/api/content/12345/child/attachment/1/data')
 
-    html, resources = nbconflux.notebook_to_page(notebook_path, page_url, 'fake-username', 'fake-pass', False, False, False, True)
+    html, resources = nbconflux.notebook_to_page(notebook_path, page_url, 'fake-username', 'fake-pass', False, False, False, True, None, 'http://myhost.com/notebook.css')
 
     # Excludes a table of contents macro
     assert 'ac:name="toc"' not in html
@@ -189,6 +191,8 @@ def test_optional_components(notebook_path, page_url, server):
     assert 'ipython.min.css' not in html
     # Includes MathJax
     assert 'MathJax' in html
+    # Test css has been overidden
+    assert 'http://myhost.com/notebook.css' in html
 
 
 def test_post_to_unknown(notebook_path, bad_page_url, server):


### PR DESCRIPTION
In this PR, I introduce a new env variable NBCONFLUX_NOTEBOOK_CSS to be able to override the default path to notebook.css

We use a lot nbconflux and love it. But on our confluence server, 'https://nbviewer.jupyter.org/' is not whitelisted. Therefore, the confluence server disallow to download the css file.
To workaround this problem, we want to inject into the confluence template a path to a notebook css located on a whitelisted url.