### PR TITLE
Upgrade to nbconvert6

### DIFF
--- a/nbconflux/exporter.py
+++ b/nbconflux/exporter.py
@@ -86,6 +86,10 @@ class ConfluenceExporter(HTMLExporter):
         c.merge(overrides)
         return c
 
+    @property
+    def template_paths(self):
+        return super().template_paths + [os.path.join(os.path.abspath(os.path.dirname(__file__)), 'templates')]
+
     def __init__(self, config, **kwargs):
         config.HTMLExporter.preprocessors = [ConfluencePreprocessor]
         config.HTMLExporter.filters = {
@@ -93,10 +97,12 @@ class ConfluenceExporter(HTMLExporter):
         }
 
         super(ConfluenceExporter, self).__init__(config=config, **kwargs)
-        self._preprocessors[-1].exporter = self
 
-        self.template_path = [os.path.abspath(os.path.dirname(__file__))]
-        self.template_file = 'confluence'
+        for preprocessor in self._preprocessors:
+            if isinstance(preprocessor, ConfluencePreprocessor):
+                preprocessor.exporter = self
+
+        self.template_file = 'confluence.tpl'
         # Must be at least a single character, or the header generator produces
         # an (invalid?) empty anchor tag that trips up bleach during
         # sanitization

--- a/nbconflux/templates/confluence.tpl
+++ b/nbconflux/templates/confluence.tpl
@@ -1,5 +1,5 @@
-{%- extends 'display_priority.tpl' -%}
-{% from 'mathjax.tpl' import mathjax %}
+{%- extends 'display_priority.j2' -%}
+{% from 'mathjax.html.j2' import mathjax %}
 
 {%- block header -%}
 {%- if resources.generate_toc %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bleach
 html5lib
-nbconvert>=5.3
+nbconvert>=6.0
 requests
 traitlets


### PR DESCRIPTION
The package is broken when used with `nbconvert>=6.0` since there were major changes to `nbconvert`.
This PR tries to fix this issue.

- In `exporter.py` in `__init__`, `ConfluenceExporter` is assigned to the `ConfluencePreprocessor` by just accessing the last element of the `self._preprocessor` list. But the position of `ConfluencePreprocessor` is not the last item of the list. In this PR it is assigned correctly
- Change `template_path` to `template_paths` and add the default templates of nbconvert
- Accommodate the changes of the template files naming in the confluence template.