### PR TITLE
fix template file not included in the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include versioneer.py
 include LICENSE
 include README.md
 include nbconflux/_version.py
-include nbconflux/confluence.tpl
+include nbconflux/templates/confluence.tpl


### PR DESCRIPTION
In the nbconvert upgrade, the template file was moved to a seperate folder, but the location of the template file was not updated in the manifest